### PR TITLE
RFC-lite: Possible API design & scope

### DIFF
--- a/example.rs
+++ b/example.rs
@@ -15,9 +15,9 @@ fn main() {
     //
     // The path is also dependant on the OS and all of this happens
     // completely transparently
-    let cfg = match confy::load("my_app") {
+    let cfg: MyConfig = match confy::load("my_app") {
         Some(cfg) => cfg,
-        None => confy::create(MyConfig {
+        None => confy::create(("my_app", MyConfig {
             /* ... initialise default ... */
         }),
     };
@@ -26,5 +26,5 @@ fn main() {
     // ...
 
     // At some point you can save/ overwrite your config
-    confy::save(cfg).unwrap(); // Returns Result
+    confy::save(("my_app", cfg).unwrap(); // Returns Result
 }

--- a/example.rs
+++ b/example.rs
@@ -26,5 +26,5 @@ fn main() {
     // ...
 
     // At some point you can save/ overwrite your config
-    confy::save(("my_app", cfg).unwrap(); // Returns Result
+    confy::save("my_app", cfg).unwrap(); // Returns Result
 }

--- a/example.rs
+++ b/example.rs
@@ -1,0 +1,30 @@
+//! This is an example of how this crate could be usable
+
+#[macro_use] extern crate confy;
+
+#[derive(Confy)]
+struct MyConfig {
+    /* ... some fields ... */
+}
+
+
+fn main() {
+
+    // Creates a folder for your app called `my_app` and the
+    // actual config file is derived from the struct name
+    //
+    // The path is also dependant on the OS and all of this happens
+    // completely transparently
+    let cfg = match confy::load("my_app") {
+        Some(cfg) => cfg,
+        None => confy::create(MyConfig {
+            /* ... initialise default ... */
+        }),
+    };
+
+    // Here `cfg` is just a usable struct
+    // ...
+
+    // At some point you can save/ overwrite your config
+    confy::save(cfg).unwrap(); // Returns Result
+}


### PR DESCRIPTION
This is a small example of how such a crate could work. There are a lot of open questions though. 

The baseline for the design of this config crate is however that a user shouldn't have to worry about what platform they're running on and should be designed with the mantra of **"Just give me a config"** in mind!

([Code Example](https://github.com/spacekookie/confy/blob/master/example.rs))

### Scope

- Integrate into CLI parsing (clap)?
- Integrate with `dotenv`?
- Missing features?

### Implementation details

- If we use serde for `serialize`/`deserialize`, do we have to explicitly declare that?
- Are there any additional options we **need** to provide to load/create/save?
  - Do we want to provide the app-name differently?
- What config format?
- Is the config format configurable, if so: how?
- Do we want to handle links between configs? Is this important?

And above all: **your thoughts?**
